### PR TITLE
Lazy load pagingu

### DIFF
--- a/app/components/DataGrid/DataGrid.php
+++ b/app/components/DataGrid/DataGrid.php
@@ -127,7 +127,7 @@ class DataGrid extends Control implements ArrayAccess, INamingContainer
 	public function bindDataTable(DibiDataSource $dataSource)
 	{
 		$this->dataSource = $dataSource;
-		$this->paginator->itemCount = count($dataSource);
+		$this->paginator->itemCount = null;
 	}
 
 
@@ -737,6 +737,10 @@ class DataGrid extends Control implements ArrayAccess, INamingContainer
 	public function render()
 	{
 		if (!$this->wasRendered) {
+			if(is_null($this->paginator->itemCount))
+			{
+				$this->paginator->itemCount = count($this->dataSource);
+			}
 			$this->wasRendered = TRUE;
 
 			if (!$this->hasColumns() || (count($this->getColumns('ActionColumn')) == count($this->getColumns()))) {
@@ -755,7 +759,7 @@ class DataGrid extends Control implements ArrayAccess, INamingContainer
 				}
 			}
 
-			if (!count($this->dataSource)) {
+			if (!$this->paginator->itemCount && !count($this->dataSource)) {
 				$this->flashMessage($this->translate("Empty datasource given."), 'info');
 			}
 


### PR DESCRIPTION
DataGrid delal trochu moc zbytecnych SQL, ktere pro muj slozitejsi dotaz zabralo ve vysledku nekolik vterin. Zmena je pridani lazy zjisteni poctu zaznamu k vypsani.
Pokud byl aplikovan filter, je zbytecne se ptat na pocet zaznamu z bindDataTable(), proto tento zaznam se nacita az v pripade, ze je to potreba (az v renderu).
