### PR TITLE
Oprava problému s filtrováním v Doctrine/QueryBuilder s Doctrine 2.0.0-BETA4+

### DIFF
--- a/DataSources/Doctrine/QueryBuilder.php
+++ b/DataSources/Doctrine/QueryBuilder.php
@@ -11,6 +11,7 @@ use Doctrine,
  * Query Builder based data source
  * @author Michael Moravec
  * @author Štěpán Svoboda
+ * @author Milan Lempera
  */
 class QueryBuilder extends DataSources\Mapped
 {
@@ -221,6 +222,7 @@ class QueryBuilder extends DataSources\Mapped
 	{
 		//\Nette\Debug::barDump(debug_backtrace());
 		$query = clone $this->qb->getQuery();
+		$query->setParameters($this->qb->getQuery()->getParameters());
 
 		$query->setHint(Doctrine\ORM\Query::HINT_CUSTOM_TREE_WALKERS, array(__NAMESPACE__ . '\Utils\CountingASTWalker'));
 		$query->setMaxResults(NULL)->setFirstResult(NULL);


### PR DESCRIPTION
V novějších verzích Doctrine (od BETA4) metoda __clone v AbstractQuery maže $this->_params, které pak chybí při vytváření dotazu na počet záznamů

https://github.com/doctrine/doctrine2/commit/0b5c694a7e1ed717954b3aac986e05da374e1713#L0R584
